### PR TITLE
mark as no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased] - ReleaseDate
 
 ### Added
+- marked as no_std
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 //! A simple library for applying procedural macros to a block. Simple example:
 //!
 //! ```


### PR DESCRIPTION
Marking as no_std will allow use for embedded systems.